### PR TITLE
[69일차] 김선희 / 연속 부분 수열 합의 개수 /

### DIFF
--- a/1st/Sunhee/programmers/연속 부분 수열 합의 개수.java
+++ b/1st/Sunhee/programmers/연속 부분 수열 합의 개수.java
@@ -1,0 +1,26 @@
+import java.util.*;
+
+class Solution {
+    public int solution(int[] elements) {
+        int answer = 0;
+        
+        HashSet<Integer> set = new HashSet<Integer>();
+        ArrayList<Integer> lst = new ArrayList<Integer>();
+        for (int i = 0; i<2; i++) {
+            for (int element : elements) {
+                lst.add(element);
+            }
+        }
+        for (int i = 0; i < elements.length; i++) {
+            for (int j = 1; j <= elements.length; j++) {
+                List<Integer> subLst = lst.subList(i, i+j);
+                int sum = 0;
+                for (int num : subLst)
+                    sum += num;
+                set.add(sum);
+            }
+        }
+        answer = set.size();
+        return answer;
+    }
+}


### PR DESCRIPTION
https://school.programmers.co.kr/learn/courses/30/lessons/131701

### ✔ 문제
 | 제목 | 사이트 | 레벨 |
 | ------ | ------- | ----- |
 | 연속 부분 수열 합의 개수 | 프로그래머스 | Level.2 |

<hr/>
 
### 📃 문제 설명
 - 철호는 수열을 가지고 놀기 좋아합니다. 어느 날 철호는 어떤 자연수로 이루어진 원형 수열의 연속하는 부분 수열의 합으로 만들 수 있는 수가 모두 몇 가지인지 알아보고 싶어졌습니다. 원형 수열이란 일반적인 수열에서 처음과 끝이 연결된 형태의 수열을 말합니다. 예를 들어 수열 [7, 9, 1, 1, 4] 로 원형 수열을 만들면 다음과 같습니다.
