### PR TITLE
[86일차] 이지인 / 연속된 부분 수열의 합

### DIFF
--- a/1st/Jiin/Sum_of_consecutive_subsequences.cpp
+++ b/1st/Jiin/Sum_of_consecutive_subsequences.cpp
@@ -1,0 +1,28 @@
+#include <string>
+#include <vector>
+#include <iostream>
+
+using namespace std;
+
+vector<int> solution(vector<int> sequence, int k) {
+    vector<int> answer(2);
+    int start = 0, end = 0;
+    int sum = 0;
+    int len = 1000001;
+    
+    for(int start = 0; start < sequence.size(); start++){
+        while(sum < k && end < sequence.size()){
+            sum += sequence[end];
+            end += 1;
+        }
+        
+        if(sum == k && len > end - start){
+            len = end - start;
+            answer[0] = start;
+            answer[1] = end - 1;
+        }
+        sum -= sequence[start];
+    }
+    
+    return answer;
+}


### PR DESCRIPTION
### ✔ 문제
 | 제목 | 사이트 | 레벨 |
 | ------ | ------- | ----- |
 | [연속된 부분 수열의 합](https://school.programmers.co.kr/learn/courses/30/lessons/178870#qna) | 프로그래머스 | Level.3 |

<hr/>
 
### 📃 문제 설명
 - 연속된 부분 수열의 합 : 다음 네 규칙을 만족하는 부분 수열을 반환하시오.
1. 기존 수열에서 임의의 두 인덱스의 원소와 그 사이의 원소를 모두 포함하는 부분 수열이어야 합니다.
2. 부분 수열의 합은 k입니다.
3. 합이 k인 부분 수열이 여러 개인 경우 길이가 짧은 수열을 찾습니다.
4. 길이가 짧은 수열이 여러 개인 경우 앞쪽(시작 인덱스가 작은)에 나오는 수열을 찾습니다.
