### PR TITLE
[76일차] 김리연 / 연속 부분 수열 합의 개수

### DIFF
--- a/2st/Riyeon/연속 부분 수열 합의 개수.java
+++ b/2st/Riyeon/연속 부분 수열 합의 개수.java
@@ -1,0 +1,18 @@
+import java.util.*;
+class Solution {
+    public int solution(int[] elements) {
+        int ele[] = new int[elements.length*2];
+        for(int i=0; i<elements.length; i++){
+            ele[i] = elements[i];
+            ele[i+elements.length] = elements[i];
+        }
+        
+        Set<Integer> set = new HashSet<>();
+        // 수열의 합
+        for(int i=0; i<elements.length; i++){
+            for(int j=0; j<elements.length; j++)
+                set.add(Arrays.stream(ele, j, j+i).sum());
+        }
+        return set.size();
+    }
+}


### PR DESCRIPTION
### ✔ 문제
 | 제목 | 사이트 | 레벨 |
 | ------ | ------- | ----- |
 | 연속 부분 수열 합의 개수 | 프로그래머스 | Level.2 |

<hr/>
 
### 📃 문제 설명
 - 연속 부분 수열 합의 개수 : 원형 수열은 처음과 끝이 연결되어 끊기는 부분이 없기 때문에 연속하는 부분 수열도 일반적인 수열보다 많아집니다.
원형 수열의 모든 원소 elements가 순서대로 주어질 때, 원형 수열의 연속 부분 수열 합으로 만들 수 있는 수의 개수를 return 하도록 solution 함수를 완성해주세요.