### PR TITLE
[125일차] 김리연 / 연도별 대장균 크기의 편차 구하기

### DIFF
--- a/2st/Riyeon/연도별 대장균 크기의 편차 구하기.sql
+++ b/2st/Riyeon/연도별 대장균 크기의 편차 구하기.sql
@@ -1,0 +1,9 @@
+with T1 as(select max(size_of_colony) as maxc,
+           year(differentiation_date)as yeard
+           from ecoli_data
+           group by yeard)
+select year(differentiation_date) as year, 
+abs(size_of_colony - T1.maxc) as year_dev, id
+from ecoli_data
+inner join T1 on year(ecoli_data.differentiation_date) = T1.yeard
+order by year, year_dev asc;


### PR DESCRIPTION
### ✔ 문제
 | 제목 | 사이트 | 레벨 |
 | ------ | ------- | ----- |
 | 연도별 대장균 크기의 편차 구하기 | 프로그래머스 | Level.2 |

<hr/>
 
### 📃 문제 설명
 - 연도별 대장균 크기의 편차 구하기 : 분화된 연도(YEAR), 분화된 연도별 대장균 크기의 편차(YEAR_DEV), 대장균 개체의 ID(ID) 를 출력하는 SQL 문을 작성해주세요. 분화된 연도별 대장균 크기의 편차는 분화된 연도별 가장 큰 대장균의 크기 - 각 대장균의 크기로 구하며 결과는 연도에 대해 오름차순으로 정렬하고 같은 연도에 대해서는 대장균 크기의 편차에 대해 오름차순으로 정렬해주세요.