### PR TITLE
[330일차] 박재영 / UCPC에서 가장 쉬운 문제 번호는?

### DIFF
--- a/3st/Jaeyoung/UCPC에서 가장 쉬운 문제 번호는.cpp
+++ b/3st/Jaeyoung/UCPC에서 가장 쉬운 문제 번호는.cpp
@@ -1,0 +1,9 @@
+#include <iostream>
+
+using namespace std;
+
+int main() {
+    cout << "A";
+
+    return 0;
+}


### PR DESCRIPTION
### ✔ 문제
 | 제목 | 사이트 | 레벨 |
 | ------ | ------- | ----- |
 | UCPC에서 가장 쉬운 문제 번호는? | 백준 / 프로그래머스 | 브론즈 V / Level.1 |

<hr/>
 
### 📃 문제 설명
 - UCPC에서 가장 쉬운 문제 번호는? : 대회 참가자는 되도록 일찍 대회의 모든 문제를 한 번씩 읽어 보는 것이 권장됩니다. 이렇게 하면 대회의 전체적인 분위기를 느낄 수 있고, 종종 비교적 쉬운 문제를 빨리 발견해서 속도에서 우위를 점할 수도 있습니다.

하지만 실제 참가자들은 다양한 전략을 사용하고, 문제들이 배치된 순서에 따라서 일부 문제를 아예 읽지 못하거나 아주 늦은 시점에 읽어 보게 될 수도 있습니다. 몇몇 대회는 이를 이용해서 각 문제가 적절한 관심을 받을 수 있도록 문제 순서를 전략적으로 정하기도 합니다.

다음은 흔히 사용되는 몇 가지 문제 배치 방식입니다.

 - 출제진이 예상하는 난이도 순으로 배치합니다. 문제의 난이도에 따라 다른 점수를 주는 대회에서 자주 쓰는 방식이며, 그렇지 않은 대회에서 이 방식을 사용하는 경우는 보통 예상 난이도 순으로 문제가 배정되었다는 공지가 이루어집니다.
 - 문제 이름 순으로 정렬합니다. 이 방식은 문제 순서가 난이도와 관련 없음을 직접적으로 보여 줄 수 있으나, 가끔 이를 역으로 이용해 문제 이름을 문제 번호에 맞춰서 짓는 경우도 있습니다.
 - 완전 무작위로 배치합니다.
 - 문제 몇 개의 위치를 고정하고, 나머지를 무작위로 배치합니다. 이 경우 주로 쉬운 문제를 앞쪽에, 어려운 문제를 뒤쪽에 놓습니다.

UCPC 예선은 가장 마지막 방법을 따라, 가장 쉬운 문제의 위치를 고정하고 나머지를 무작위로 배치하는 방법을 사용해 왔습니다. 다음은 지금까지 UCPC 예선에서 출제진이 의도한 가장 쉬운 문제의 번호와 문제 제목입니다.

 - UCPC 2018 예선: A번, 수학은 체육과목 입니다
 - UCPC 2019 예선: A번, 수학은 체육과목 입니다 2
 - UCPC 2020 예선: A번, 수학은 비대면강의입니다
 - UCPC 2021 예선: A번, 수학은 체육과목 입니다 3
이를 바탕으로, 각 연도별로 출제진이 의도한 가장 쉬운 문제의 번호를 출력하는 프로그램을 작성해 봅시다.