### PR TITLE
[151일차] 최한이 / 연도 별 평균 미세먼지 농도 조회하기

### DIFF
--- a/4st/Hani/programmer/연도 별 평균 미세먼지 농도 조회하기.sql
+++ b/4st/Hani/programmer/연도 별 평균 미세먼지 농도 조회하기.sql
@@ -1,0 +1,8 @@
+select
+    YEAR(YM) as YEAR,
+    round(avg(PM_VAL1), 2) as 'PM10',
+    round(avg(PM_VAL2), 2) as 'PM2.5'
+from AIR_POLLUTION
+where LOCATION2 = '수원'
+group by YEAR(YM)
+order by YEAR(YM);


### PR DESCRIPTION
#https://school.programmers.co.kr/learn/courses/30/lessons/284530#
# ✔ 문제
 | 제목 | 사이트 | 레벨 |
 | ------ | ------- | ----- |
 | 연도 별 평균 미세먼지 농도 조회하기 | 프로그래머스 | Level.2 |

<hr/>
 
### 📃 문제 설명
 - 연도 별 평균 미세먼지 농도 조회하기 : AIR_POLLUTION 테이블에서 수원 지역의 연도 별 평균 미세먼지 오염도와 평균 초미세먼지 오염도를 조회하는 SQL문을 작성해주세요. 이때, 평균 미세먼지 오염도와 평균 초미세먼지 오염도의 컬럼명은 각각 PM10, PM2.5로 해 주시고, 값은 소수 셋째 자리에서 반올림해주세요.
결과는 연도를 기준으로 오름차순 정렬해주세요.
